### PR TITLE
Update Container Port to 9000 in Kustomization for crossmap-dev and Capture Dependencies

### DIFF
--- a/home/namespaced/crossmap-dev/patch-container-port.yml
+++ b/home/namespaced/crossmap-dev/patch-container-port.yml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossmap-api
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        ports:
+        - name: http
+          containerPort: 9000
+        env:
+        - name: PORT
+          value: "9000"


### PR DESCRIPTION
Patch the kustomization at home/namespaced/crossmap-dev to change the container port to 9000.  Try to capture all dependencies.